### PR TITLE
Add additional markup to the form elements

### DIFF
--- a/assets/dco-comment-attachment.css
+++ b/assets/dco-comment-attachment.css
@@ -1,3 +1,7 @@
 .dco-image-attachment {
 	line-height: 0;
 }
+
+.comment-form-attachment span {
+	display: block;
+}

--- a/includes/class-dco-ca.php
+++ b/includes/class-dco-ca.php
@@ -115,13 +115,9 @@ class DCO_CA extends DCO_CA_Base {
 		ob_start();
 		?>
 		<p class="comment-form-attachment">
-			<span class="comment-form-attachment__fields">
-				<?php
-				$this->form_element( 'label' );
-				$this->form_element( 'input' );
-				?>
-			</span>
 			<?php
+			$this->form_element( 'label' );
+			$this->form_element( 'input' );
 			$this->form_element( 'upload-size' );
 			$this->form_element( 'file-types' );
 			?>
@@ -209,7 +205,7 @@ class DCO_CA extends DCO_CA_Base {
 				 *                       file size form element.
 				 * @param string $max_upload_size The max upload file size with format.
 				 */
-				$markup = apply_filters( 'dco_ca_form_element_upload_size', '<br>' . ob_get_clean(), $max_upload_size );
+				$markup = apply_filters( 'dco_ca_form_element_upload_size', ob_get_clean(), $max_upload_size );
 				break;
 			case 'file-types':
 				ob_start();
@@ -233,7 +229,7 @@ class DCO_CA extends DCO_CA_Base {
 				 *                       types list form element.
 				 * @param string $types The file types list allowed for upload.
 				 */
-				$markup = apply_filters( 'dco_ca_form_element_file_types', '<br>' . ob_get_clean(), $types );
+				$markup = apply_filters( 'dco_ca_form_element_file_types', ob_get_clean(), $types );
 				break;
 		}
 

--- a/includes/class-dco-ca.php
+++ b/includes/class-dco-ca.php
@@ -114,14 +114,18 @@ class DCO_CA extends DCO_CA_Base {
 	public function add_attachment_field( $submit_field ) {
 		ob_start();
 		?>
-		<div class="comment-form-attachment">
+		<p class="comment-form-attachment">
+			<span class="comment-form-attachment__fields">
+				<?php
+				$this->form_element( 'label' );
+				$this->form_element( 'input' );
+				?>
+			</span>
 			<?php
-			$this->form_element( 'label' );
-			$this->form_element( 'input' );
 			$this->form_element( 'upload-size' );
 			$this->form_element( 'file-types' );
 			?>
-		</div>
+		</p>
 		<?php
 		/**
 		 * Filters the attachment field markup.
@@ -173,7 +177,7 @@ class DCO_CA extends DCO_CA_Base {
 				ob_start();
 				$name = $this->get_upload_field_name();
 				?>
-				<input  class="comment-form-attachment__input" id="attachment" name="<?php echo esc_attr( $name ); ?>" type="file" />
+				<input class="comment-form-attachment__input" id="attachment" name="<?php echo esc_attr( $name ); ?>" type="file" />
 				<?php
 				/**
 				 * Filters the input form element markup.
@@ -189,12 +193,12 @@ class DCO_CA extends DCO_CA_Base {
 				ob_start();
 				$max_upload_size = $this->get_max_upload_size( true );
 				?>
-				<div class="comment-form-attachment__file-size-notice">
-				<?php
-				/* translators: %s: the maximum allowed upload file size */
-				printf( esc_html__( 'The maximum upload file size: %s.', 'dco-comment-attachment' ), esc_html( $max_upload_size ) );
-				?>
-				</div>
+				<span class="comment-form-attachment__file-size-notice">
+					<?php
+					/* translators: %s: the maximum allowed upload file size */
+					printf( esc_html__( 'The maximum upload file size: %s.', 'dco-comment-attachment' ), esc_html( $max_upload_size ) );
+					?>
+				</span>
 				<?php
 				/**
 				 * Filters the maximum upload file size form element markup.
@@ -205,7 +209,7 @@ class DCO_CA extends DCO_CA_Base {
 				 *                       file size form element.
 				 * @param string $max_upload_size The max upload file size with format.
 				 */
-				$markup = apply_filters( 'dco_ca_form_element_upload_size', ob_get_clean(), $max_upload_size );
+				$markup = apply_filters( 'dco_ca_form_element_upload_size', '<br>' . ob_get_clean(), $max_upload_size );
 				break;
 			case 'file-types':
 				ob_start();
@@ -213,12 +217,12 @@ class DCO_CA extends DCO_CA_Base {
 				$types = $this->get_allowed_file_types( 'html' );
 				$this->disable_filter_upload();
 				?>
-				<div class="comment-form-attachment__file-types-notice">
-				<?php
-				/* translators: %s: the allowed file types list */
-				printf( esc_html__( 'You can upload: %s.', 'dco-comment-attachment' ), wp_kses_data( $types ) );
-				?>
-				</div>
+				<span class="comment-form-attachment__file-types-notice">
+					<?php
+					/* translators: %s: the allowed file types list */
+					printf( esc_html__( 'You can upload: %s.', 'dco-comment-attachment' ), wp_kses_data( $types ) );
+					?>
+				</span>
 				<?php
 				/**
 				 * Filters the allowed file types list form element markup.
@@ -229,7 +233,7 @@ class DCO_CA extends DCO_CA_Base {
 				 *                       types list form element.
 				 * @param string $types The file types list allowed for upload.
 				 */
-				$markup = apply_filters( 'dco_ca_form_element_file_types', ob_get_clean(), $types );
+				$markup = apply_filters( 'dco_ca_form_element_file_types', '<br>' . ob_get_clean(), $types );
 				break;
 		}
 

--- a/includes/class-dco-ca.php
+++ b/includes/class-dco-ca.php
@@ -114,14 +114,14 @@ class DCO_CA extends DCO_CA_Base {
 	public function add_attachment_field( $submit_field ) {
 		ob_start();
 		?>
-		<p class="comment-form-attachment">
+		<div class="comment-form-attachment">
 			<?php
 			$this->form_element( 'label' );
 			$this->form_element( 'input' );
 			$this->form_element( 'upload-size' );
 			$this->form_element( 'file-types' );
 			?>
-		</p>
+		</div>
 		<?php
 		/**
 		 * Filters the attachment field markup.
@@ -150,7 +150,7 @@ class DCO_CA extends DCO_CA_Base {
 				ob_start();
 				$required = $this->get_option( 'required_attachment' );
 				?>
-				<label for="attachment">
+				<label class="comment-form-attachment__label" for="attachment">
 					<?php
 					esc_html_e( 'Attachment', 'dco-comment-attachment' );
 					if ( $required ) {
@@ -173,7 +173,7 @@ class DCO_CA extends DCO_CA_Base {
 				ob_start();
 				$name = $this->get_upload_field_name();
 				?>
-				<input id="attachment" name="<?php echo esc_attr( $name ); ?>" type="file" />
+				<input  class="comment-form-attachment__input" id="attachment" name="<?php echo esc_attr( $name ); ?>" type="file" />
 				<?php
 				/**
 				 * Filters the input form element markup.
@@ -188,9 +188,14 @@ class DCO_CA extends DCO_CA_Base {
 			case 'upload-size':
 				ob_start();
 				$max_upload_size = $this->get_max_upload_size( true );
+				?>
+				<div class="comment-form-attachment__file-size-notice">
+				<?php
 				/* translators: %s: the maximum allowed upload file size */
 				printf( esc_html__( 'The maximum upload file size: %s.', 'dco-comment-attachment' ), esc_html( $max_upload_size ) );
-
+				?>
+				</div>
+				<?php
 				/**
 				 * Filters the maximum upload file size form element markup.
 				 *
@@ -200,16 +205,21 @@ class DCO_CA extends DCO_CA_Base {
 				 *                       file size form element.
 				 * @param string $max_upload_size The max upload file size with format.
 				 */
-				$markup = apply_filters( 'dco_ca_form_element_upload_size', '<br>' . ob_get_clean(), $max_upload_size );
+				$markup = apply_filters( 'dco_ca_form_element_upload_size', ob_get_clean(), $max_upload_size );
 				break;
 			case 'file-types':
 				ob_start();
 				$this->enable_filter_upload();
 				$types = $this->get_allowed_file_types( 'html' );
 				$this->disable_filter_upload();
+				?>
+				<div class="comment-form-attachment__file-types-notice">
+				<?php
 				/* translators: %s: the allowed file types list */
 				printf( esc_html__( 'You can upload: %s.', 'dco-comment-attachment' ), wp_kses_data( $types ) );
-
+				?>
+				</div>
+				<?php
 				/**
 				 * Filters the allowed file types list form element markup.
 				 *
@@ -219,7 +229,7 @@ class DCO_CA extends DCO_CA_Base {
 				 *                       types list form element.
 				 * @param string $types The file types list allowed for upload.
 				 */
-				$markup = apply_filters( 'dco_ca_form_element_file_types', '<br>' . ob_get_clean(), $types );
+				$markup = apply_filters( 'dco_ca_form_element_file_types', ob_get_clean(), $types );
 				break;
 		}
 


### PR DESCRIPTION
This PR adds some basic container markup to the DCO Comment Attachment form elements so that they can be more easily targeted with CSS.

This doesn't change the default layout of the output, it just provides wrapping `<div>`s around the form elements and both the max file size and file types notices.