### PR TITLE
Fix broken parsing of referer string

### DIFF
--- a/assets/dco-comment-attachment-admin.js
+++ b/assets/dco-comment-attachment-admin.js
@@ -57,9 +57,21 @@
 		// Only for DCO_CA_Admin::show_bulk_action_message()
 		if ( $( '#the-comment-list' ).length ) {
 			const $referer = $( '[name="_wp_http_referer"]' );
-			const params = new URLSearchParams( $referer.val() );
+			const referer = $referer.val();
+			const refererQueryStringIndex = referer.indexOf( '?' );
+			
+			if ( refererQueryStringIndex === -1 ) {
+				return;
+			}
+			
+			const refererUrl = referer.substr( 0, refererQueryStringIndex );
+			const refererQueryString = referer.substr( refererQueryStringIndex );
+			
+			const params = new URLSearchParams( refererQueryString );
 			params.delete( 'deletedattachment' );
-			$referer.val( decodeURIComponent( params.toString() ) );
+			
+			const filteredParams = params.toString();
+			$referer.val( refererUrl + ( filteredParams.length ? '?' + filteredParams : '' ) );
 		}
 
 		$( '#dco-comment-attachment' ).on(

--- a/assets/dco-comment-attachment-admin.js
+++ b/assets/dco-comment-attachment-admin.js
@@ -65,13 +65,13 @@
 			}
 			
 			const refererUrl = referer.substr( 0, refererQueryStringIndex );
-			const refererQueryString = referer.substr( refererQueryStringIndex );
+			let refererQueryString = referer.substr( refererQueryStringIndex );
 			
 			const params = new URLSearchParams( refererQueryString );
 			params.delete( 'deletedattachment' );
 			
-			const filteredParams = params.toString();
-			$referer.val( refererUrl + ( filteredParams.length ? '?' + filteredParams : '' ) );
+			refererQueryString = params.toString();
+			$referer.val( refererUrl + ( refererQueryString.length ? '?' + refererQueryString : '' ) );
 		}
 
 		$( '#dco-comment-attachment' ).on(


### PR DESCRIPTION
Ref: https://github.com/yadenis/DCO-Comment-Attachment/blob/v2.4.0/assets/dco-comment-attachment-admin.js#L60

When there are no query string parameters in the referer, the final string becomes `/wp/wp-admin/edit-comments.php=` which is invalid and appears to cause a 404 later down the line.

It seems that this block of code doesn’t actually work, at least in my testing on Chrome:

```
const params = new URLSearchParams( '/wp-comments.php?foo=bar' );
params.delete( 'foo' );
params.toString(); // '%2Fwp-comments.php%3Ffoo=bar' (foo param not deleted)
```

You need to pass in only the query string to `URLSearchParams`

More details in the forum https://wordpress.org/support/topic/plugin-causes-404-on-admin-bulk-comment-action/#post-16399449